### PR TITLE
fix timeout error occuring in test

### DIFF
--- a/test/unit/test_application.js
+++ b/test/unit/test_application.js
@@ -79,7 +79,7 @@ exports['test express app listen is called'] = function(done) {
   runApp();
 
   mock.verify();
-  return done();
+  done();
 };
 
 exports['test all mbaas routes are mounted'] = function(done) {


### PR DESCRIPTION
## Motivation
Running npm test throws the following error:
```
1)  test express app listen is called:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
      at Context.exports.test express app listen is called (test/unit/test_application.js:82:10)
```

## Result
Remove the `return` to ensure that the `done()` callback is being called.